### PR TITLE
Release docker image for arm64.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+ist: focal
+
+services:
+  - docker
+
+before_script:
+  - mkdir -p ~/.docker/cli-plugins
+  - wget -O - https://github.com/docker/buildx/releases/download/v0.5.1/buildx-v0.5.1.linux-amd64 > ~/.docker/cli-plugins/docker-buildx
+  - chmod a+x ~/.docker/cli-plugins/docker-buildx
+  - docker run --rm --privileged docker/binfmt:a7996909642ee92942dcd6cff44b9b95f08dad64
+  - docker buildx create --use --name mybuilder
+
+script:
+  - docker login -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}
+  - docker buildx build --platform linux/amd64,linux/arm64 -t w32blaster/telegram-notification-resource:latest --push .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gliderlabs/alpine:3.4
+FROM alpine:3.14.1
 
 RUN apk add --no-cache curl bash jq gettext
 


### PR DESCRIPTION
The following file has been created and modified:
Added .travis.yml file to build and push the image for both amd64 and arm64 platforms.
Base image is updated from gliderlabs/alpine:3.4 to alpine:3.14.1 as alpine:3.14.1 has arm64 support present in it.

Signed-off-by: odidev odidev@puresoftware.com